### PR TITLE
Change h3 HTML tag to h2 to apply CSS styling properly

### DIFF
--- a/app/templates/progress.html
+++ b/app/templates/progress.html
@@ -3,7 +3,7 @@
 <main class="progress-content">
     <p><i class="fa fa-refresh fa-spin fa-3x fa-fw"></i></p>
     <h1>Data8 Interact Server</h1>
-    <h3> Please use Google Chrome to avoid any errors! </h3>
+    <h2> Please use Google Chrome to avoid any errors! </h2>
     <p class="reversed">Est. time left: <span class="time">30 seconds</span>
         &middot;
     Status:


### PR DESCRIPTION
Last pull request did not properly note styling does not apply to h3 tag by default. Changes h3 tag to h2 tag so that styling in style.css applies
